### PR TITLE
Update boron isotope functions

### DIFF
--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -13,9 +13,9 @@ def get_epsilonB():
     """
     Klochko epsilon for B fractionation
     """
-    return alpha_2_epsilon(get_alphaB())
+    return alpha_to_epsilon(get_alphaB())
 
-def alpha_2_epsilon(alphaB):
+def alpha_to_epsilon(alphaB):
     """
     Convert alpha to epsilon (which is alpha in delta space)
 
@@ -30,7 +30,7 @@ def alpha_2_epsilon(alphaB):
         alphaB expressed in delta notation (AKA epsilonB).
     """
     return (alphaB-1)*1000
-def epsilon_2_alpha(epsilonB):
+def epsilon_to_alpha(epsilonB):
     """
     Convert epsilon to alpha
 
@@ -47,7 +47,7 @@ def epsilon_2_alpha(epsilonB):
     return (epsilonB/1000)+1
 
 # Isotope Unit Converters
-def A11_2_d11(A11, SRM_ratio=4.04367):
+def A11_to_d11(A11, SRM_ratio=4.04367):
     """
     Convert fractional abundance (A11) to delta notation (d11).
 
@@ -64,7 +64,7 @@ def A11_2_d11(A11, SRM_ratio=4.04367):
         A11 expressed in delta notation (d11).
     """
     return ((A11 / (1 - A11)) / SRM_ratio - 1) * 1000
-def A11_2_R11(A11):
+def A11_to_R11(A11):
     """
     Convert fractional abundance (A11) to isotope ratio (R11).
 
@@ -79,7 +79,7 @@ def A11_2_R11(A11):
         A11 expressed as an isotope ratio (R11).
     """
     return A11 / (1 - A11)
-def d11_2_A11(d11, SRM_ratio=4.04367):
+def d11_to_A11(d11, SRM_ratio=4.04367):
     """
     Convert delta notation (d11) to fractional abundance (A11).
 
@@ -96,7 +96,7 @@ def d11_2_A11(d11, SRM_ratio=4.04367):
        Delta notation (d11) expressed as fractional abundance (A11).
     """
     return SRM_ratio * (d11 / 1000 + 1) / (SRM_ratio * (d11 / 1000 + 1) + 1)
-def d11_2_R11(d11, SRM_ratio=4.04367):
+def d11_to_R11(d11, SRM_ratio=4.04367):
     """
     Convert delta notation (d11) to isotope ratio (R11).
 
@@ -113,7 +113,7 @@ def d11_2_R11(d11, SRM_ratio=4.04367):
        Delta notation (d11) expressed as isotope ratio (R11).
     """
     return (d11 / 1000 + 1) * SRM_ratio
-def R11_2_d11(R11, SRM_ratio=4.04367):
+def R11_to_d11(R11, SRM_ratio=4.04367):
     """
     Convert isotope ratio (R11) to delta notation (d11).
 
@@ -130,7 +130,7 @@ def R11_2_d11(R11, SRM_ratio=4.04367):
         R11 expressed in delta notation (d11).
     """
     return (R11 / SRM_ratio - 1) * 1000
-def R11_2_A11(R11):
+def R11_to_A11(R11):
     """
     Convert isotope ratio (R11) to fractional abundance (A11).
 
@@ -442,9 +442,9 @@ def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
     array-like
         pH on the total scale
     """
-    AB4 = d11_2_A11(d11B4)
-    ABT = d11_2_A11(d11BT)
-    alpha = epsilon_2_alpha(epsilon)
+    AB4 = d11_to_A11(d11B4)
+    ABT = d11_to_A11(d11BT)
+    alpha = epsilon_to_alpha(epsilon)
 
     return cp(calculate_H(Ks,alpha,ABT,AB4))
 def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
@@ -467,11 +467,11 @@ def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     array-like
         The stoichiometric equilibrium constant for boron (KB)
     """
-    AB4 = d11_2_A11(d11B4)
-    ABT = d11_2_A11(d11BT)
+    AB4 = d11_to_A11(d11B4)
+    ABT = d11_to_A11(d11BT)
     H = ch(pH)
 
-    alphaB = epsilon_2_alpha(epsilonB)
+    alphaB = epsilon_to_alpha(epsilonB)
 
     return cp(calculate_KB(H,alphaB,ABT,AB4))
 def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
@@ -494,10 +494,10 @@ def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     array-like
         The isotope ratio 11B/10B in BT - delta units (d11BT)
     """
-    AB4 = d11_2_A11(d11B4)
-    alpha = epsilon_2_alpha(epsilonB)
+    AB4 = d11_to_A11(d11B4)
+    alpha = epsilon_to_alpha(epsilonB)
     H = ch(pH)
-    return A11_2_d11(calculate_ABT(H,KB,alpha,AB4))
+    return A11_to_d11(calculate_ABT(H,KB,alpha,AB4))
 def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     """
     Calculates the isotope ratio of borate ion in delta units
@@ -518,10 +518,10 @@ def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     array-like
         The isotope ratio 11B/10B in BO4 - delta units
     """
-    ABOT = d11_2_A11(d11BT)
-    alpha = epsilon_2_alpha(epsilonB)
+    ABOT = d11_to_A11(d11BT)
+    alpha = epsilon_to_alpha(epsilonB)
 
-    return A11_2_d11(calculate_AB4(ch(pH),KB,ABOT,alpha))
+    return A11_to_d11(calculate_AB4(ch(pH),KB,ABOT,alpha))
 def calculate_epsilon(pH, KB, d11BT, d11B4):
     """
     Returns isotope ratio of borate ion in delta units
@@ -542,10 +542,10 @@ def calculate_epsilon(pH, KB, d11BT, d11B4):
     array-like
         fractionation factor between BO3 and BO4 in delta units (epsilon)
     """
-    AB4 = d11_2_A11(d11B4)
-    ABT = d11_2_A11(d11BT)
+    AB4 = d11_to_A11(d11B4)
+    ABT = d11_to_A11(d11BT)
     H = ch(pH)
 
     alpha = calculate_alpha_AB4(H,KB,ABT,AB4)
 
-    return alpha_2_epsilon(alpha)
+    return alpha_to_epsilon(alpha)

--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -147,13 +147,13 @@ def R11_2_A11(R11):
     return R11 / (1 + R11)
 
 # Alpha Converters
-def ABO3_to_ABO4(ABO3,alphaB):
+def AB3_to_AB4(AB3,alphaB):
     """
     Converts isotope fractional abundance of boric acid to isotope fraction abundance of borate ion
 
     Parameters
     ----------
-    ABO3 : array-like
+    AB3 : array-like
         The fractional abundance of boric acid (B(OH)3)
     alphaB : array-like
         The isotope fractionation factor for (11/10 BO3)/(11/10 BO4).
@@ -161,18 +161,18 @@ def ABO3_to_ABO4(ABO3,alphaB):
     Returns
     -------
     array-like
-        ABO4 - the fractional abundance of borate ion (B(OH)4)
+        AB4 - the fractional abundance of borate ion (B(OH)4)
     """
-    return (1 / ((alphaB / ABO3) - alphaB + 1) )
-def ABO3_or_ABO4(ABO3,ABO4,alphaB):
+    return (1 / ((alphaB / AB3) - alphaB + 1) )
+def AB3_or_AB4(AB3,AB4,alphaB):
     """
-    Helper function to determine ABO4 if ABO3 is None
+    Helper function to determine AB4 if AB3 is None
 
     Parameters
     ----------
-    ABO3 : array-like
+    AB3 : array-like
         The fractional abundance of boric acid (B(OH)3)
-    ABO4 : array-like
+    AB4 : array-like
         The fractional abundance of borate ion (B(OH)4)
     alphaB : array-like
         The isotope fractionation factor for (11/10 BO3)/(11/10 BO4).
@@ -180,19 +180,19 @@ def ABO3_or_ABO4(ABO3,ABO4,alphaB):
     Returns
     -------
     array-like
-        ABO4 - the fractional abundance of borate ion (B(OH)4)
+        AB4 - the fractional abundance of borate ion (B(OH)4)
     """
-    if (ABO4 is None and ABO3 is None) or (ABO4 is not None and ABO3 is not None):
-        raise(ValueError("Either ABO4 or ABO3 must be specified"))
-    elif ABO4 is None and ABO3 is not None:
-        ABO4 = ABO3_to_ABO4(ABO3,alphaB)
-    return ABO4
+    if (AB4 is None and AB3 is None) or (AB4 is not None and AB3 is not None):
+        raise(ValueError("Either AB4 or AB3 must be specified"))
+    elif AB4 is None and AB3 is not None:
+        AB4 = AB3_to_AB4(AB3,alphaB)
+    return AB4
 
 # Base Functions
 # Calculate total boron isotope fractional abundance using borate ion (B(OH)4)
-def calculate_ABT(H, Ks, alphaB, ABO4=None, ABO3=None):
+def calculate_ABT(H, Ks, alphaB, AB4=None, AB3=None):
     """
-    Calculates ABT from pH (total scale) and ABO4.
+    Calculates ABT from pH (total scale) and AB4.
 
     Parameters
     ----------    
@@ -202,9 +202,9 @@ def calculate_ABT(H, Ks, alphaB, ABO4=None, ABO3=None):
         pH on the Total scale
     alphaB : array-like
         The fractionation factor between B(OH)3 and B(OH)4-
-    ABO4 : array-like
+    AB4 : array-like
         The fractional abundance of 11B in B(OH)4.
-    ABO3 : array-like
+    AB3 : array-like
         The fractional abundance of 11B in B(OH)3.
 
     Returns
@@ -212,26 +212,26 @@ def calculate_ABT(H, Ks, alphaB, ABO4=None, ABO3=None):
     array-like
         The fractional abundance of 11B in total B (ABT).
     """
-    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
+    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
 
     chiB = chiB_calc(H, Ks)
     return (
-        ABO4
+        AB4
         * (
-            -ABO4 * alphaB * chiB
-            + ABO4 * alphaB
-            + ABO4 * chiB
-            - ABO4
+            -AB4 * alphaB * chiB
+            + AB4 * alphaB
+            + AB4 * chiB
+            - AB4
             + alphaB * chiB
             - chiB
             + 1
         )
-        / (ABO4 * alphaB - ABO4 + 1))
+        / (AB4 * alphaB - AB4 + 1))
 
 # Calculate pH using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_H(Ks, alphaB, ABT, ABO4=None, ABO3=None):
+def calculate_H(Ks, alphaB, ABT, AB4=None, AB3=None):
     """
-    Calculates pHtot from ABO4 and ABT. 
+    Calculates pHtot from AB4 and ABT. 
 
     Parameters
     ----------
@@ -241,7 +241,7 @@ def calculate_H(Ks, alphaB, ABT, ABO4=None, ABO3=None):
         fractionation factor between B(OH)3 and B(OH)4-
     ABT : float or array-like
         fractional abundance of 11B in total B
-    ABO4 : float or array-like
+    AB4 : float or array-like
         fractional abundance of 11B in B(OH)4-
         
     Returns
@@ -249,14 +249,14 @@ def calculate_H(Ks, alphaB, ABT, ABO4=None, ABO3=None):
     array-like
         pH on the total scale.
     """
-    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
+    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
 
-    return (Ks.KB / ((alphaB / (1 - ABO4 + alphaB * ABO4) - 1) / (ABT / ABO4 - 1) - 1))
+    return (Ks.KB / ((alphaB / (1 - AB4 + alphaB * AB4) - 1) / (ABT / AB4 - 1) - 1))
 
 # Calculate isotope fractional abundance of boric acid (B(OH)3)
-def calculate_ABO3(H, Ks, ABT, alphaB):
+def calculate_AB3(H, Ks, ABT, alphaB):
     """
-    Calculate ABO3 from H and ABT
+    Calculate AB3 from H and ABT
 
     Parameters
     ----------
@@ -299,9 +299,9 @@ def calculate_ABO3(H, Ks, ABT, alphaB):
     ) / (2 * chiB * (alphaB - 1))
 
 # Calculate isotope fractional abundance of borate ion (B(OH)4)
-def calculate_ABO4(H, Ks, ABT, alphaB):
+def calculate_AB4(H, Ks, ABT, alphaB):
     """
-    Calculate ABO4 from H and ABT
+    Calculate AB4 from H and ABT
 
     Parameters
     ----------
@@ -344,9 +344,9 @@ def calculate_ABO4(H, Ks, ABT, alphaB):
     ) / (2 * alphaB * chiB - 2 * alphaB - 2 * chiB + 2)
 
 # Calculate alpha using isotope fractional abundance of boric acid (B(OH)3)
-def calculate_alpha_ABO3(H, Ks, ABT, ABO3):
+def calculate_alpha_AB3(H, Ks, ABT, AB3):
     """
-    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (ABO3)
+    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (AB3)
 
     Parameters
     ----------
@@ -356,7 +356,7 @@ def calculate_alpha_ABO3(H, Ks, ABT, ABO3):
         The activity of Hydrogen ions in mol kg-1
     ABT : array-like
         The fractional abundance of 11B in total B.
-    ABO3 : array-like
+    AB3 : array-like
         The fractional abundance of 11B in boric acid (B(OH)3).
 
     Returns
@@ -365,13 +365,13 @@ def calculate_alpha_ABO3(H, Ks, ABT, ABO3):
         The fractionation factor between B(OH)3 and B(OH)4- (alpha)
     """
     return ( (1
-            / ((H/Ks.KB) * (ABT - ABO3) + ABT)) 
-            / (ABO3 -1))
+            / ((H/Ks.KB) * (ABT - AB3) + ABT)) 
+            / (AB3 -1))
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_alpha_ABO4(H, Ks, ABT, ABO4):
+def calculate_alpha_AB4(H, Ks, ABT, AB4):
     """
-    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (ABO3)
+    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (AB3)
 
     Parameters
     ----------
@@ -381,7 +381,7 @@ def calculate_alpha_ABO4(H, Ks, ABT, ABO4):
         The activity of Hydrogen ions in mol kg-1
     ABT : array-like
         The fractional abundance of 11B in total B.
-    ABO4 : array-like
+    AB4 : array-like
         The fractional abundance of 11B in borate ion (B(OH)4).
 
     Returns
@@ -389,11 +389,11 @@ def calculate_alpha_ABO4(H, Ks, ABT, ABO4):
     array-like
         The fractionation factor between B(OH)3 and B(OH)4- (alpha)
     """
-    return ( (1/ABO4 - 1)
-            / (1 / (ABT - ((ABO4-ABT)/(H/Ks.KB))) -1) )
+    return ( (1/AB4 - 1)
+            / (1 / (ABT - ((AB4-ABT)/(H/Ks.KB))) -1) )
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_KB(H, alphaB, ABT, ABO4=None, ABO3=None):
+def calculate_KB(H, alphaB, ABT, AB4=None, AB3=None):
     """
     Calculate stoichiometric equilibrium constant for boron
 
@@ -405,9 +405,9 @@ def calculate_KB(H, alphaB, ABT, ABO4=None, ABO3=None):
         The fractionation factor between B(OH)3 and B(OH)4-
     ABT : array-like
         The fractional abundance of 11B in total B.
-    ABO4 : array-like
+    AB4 : array-like
         The fractional abundance of 11B in borate ion (B(OH)4).
-    ABO3 : array-like
+    AB3 : array-like
         The fractional abundance of 11B in boric acid (B(OH)3).
 
     Returns
@@ -415,11 +415,11 @@ def calculate_KB(H, alphaB, ABT, ABO4=None, ABO3=None):
     array-like
         The stoichiometric equilibrium constant for boron (KB)
     """
-    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
+    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
     return (H
-            / ((ABO4 - ABT)
+            / ((AB4 - ABT)
             / ( ABT 
-            - 1 / ( (1/alphaB) * (1/ABO4 -1) + 1) )))
+            - 1 / ( (1/alphaB) * (1/AB4 -1) + 1) )))
 
 # Wrapper functions using delta values
 def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
@@ -442,11 +442,11 @@ def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
     array-like
         pH on the total scale
     """
-    ABO4 = d11_2_A11(d11B4)
+    AB4 = d11_2_A11(d11B4)
     ABT = d11_2_A11(d11BT)
     alpha = epsilon_2_alpha(epsilon)
 
-    return cp(calculate_H(Ks,alpha,ABT,ABO4))
+    return cp(calculate_H(Ks,alpha,ABT,AB4))
 def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     """
     Calculate stoichiometric equilibrium constant for boron with delta inputs
@@ -467,13 +467,13 @@ def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     array-like
         The stoichiometric equilibrium constant for boron (KB)
     """
-    ABO4 = d11_2_A11(d11B4)
+    AB4 = d11_2_A11(d11B4)
     ABT = d11_2_A11(d11BT)
     H = ch(pH)
 
     alphaB = epsilon_2_alpha(epsilonB)
 
-    return cp(calculate_KB(H,alphaB,ABT,ABO4))
+    return cp(calculate_KB(H,alphaB,ABT,AB4))
 def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     """
     Calcluates the isotope ratio of total boron in delta units
@@ -494,10 +494,10 @@ def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     array-like
         The isotope ratio 11B/10B in BT - delta units (d11BT)
     """
-    ABO4 = d11_2_A11(d11B4)
+    AB4 = d11_2_A11(d11B4)
     alpha = epsilon_2_alpha(epsilonB)
     H = ch(pH)
-    return A11_2_d11(calculate_ABT(H,KB,alpha,ABO4))
+    return A11_2_d11(calculate_ABT(H,KB,alpha,AB4))
 def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     """
     Calculates the isotope ratio of borate ion in delta units
@@ -521,7 +521,7 @@ def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     ABOT = d11_2_A11(d11BT)
     alpha = epsilon_2_alpha(epsilonB)
 
-    return A11_2_d11(calculate_ABO4(ch(pH),KB,ABOT,alpha))
+    return A11_2_d11(calculate_AB4(ch(pH),KB,ABOT,alpha))
 def calculate_epsilon(pH, KB, d11BT, d11B4):
     """
     Returns isotope ratio of borate ion in delta units
@@ -542,10 +542,10 @@ def calculate_epsilon(pH, KB, d11BT, d11B4):
     array-like
         fractionation factor between BO3 and BO4 in delta units (epsilon)
     """
-    ABO4 = d11_2_A11(d11B4)
+    AB4 = d11_2_A11(d11B4)
     ABT = d11_2_A11(d11BT)
     H = ch(pH)
 
-    alpha = calculate_alpha_ABO4(H,KB,ABT,ABO4)
+    alpha = calculate_alpha_AB4(H,KB,ABT,AB4)
 
     return alpha_2_epsilon(alpha)

--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -12,14 +12,6 @@ def alphaB_calc(**kwargs):
     """
     return 1.0272
 
-
-def alphaB_calc(TempC):
-    """
-    Temperature-sensitive alpha from Honisch et al, 2008
-    """    
-    # return 1.0293 - 0.000082 * TempC
-
-
 # pH_ABO3 - ABT
 def pH_ABO3(pH, ABO3, Ks, alphaB):
     """

--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -26,37 +26,125 @@ def epsilon_2_alpha(epsilonB):
     """
     return (epsilonB/1000)+1
 
-
-# Calculate total boron isotope fractional abundance using boric acid (B(OH)3)
-def ABT_using_ABO3(pH, Ks, alphaB, ABO3):
+# Isotope Unit Converters
+def A11_2_d11(A11, SRM_ratio=4.04367):
     """
-    Calculates ABT from pH (total scale) and ABO3.
+    Convert fractional abundance (A11) to delta notation (d11).
 
     Parameters
     ----------
-    pH : array-like
-        pH on the Total scale
-    ABO3 : arra-like
-        The fractional abundance of 11B in B(OH)3.
-    Ks : dict
-        A dictionary of stoichiometric equilibrium constants.
-    alphaB : array-like
-        The fractionation factor between BO3 and BO4.
+    A11 : array-like
+        The fractional abundance of 11B: 11B / (11B + 10B).
+    SRM_ratio : float, optional
+        The 11B/10B of the SRM, by default NIST951 which is 4.04367
 
     Returns
     -------
     array-like
-        The fractional abundance of 11B in total B (ABT).
+        A11 expressed in delta notation (d11).
     """
-    H = ch(pH)
-    chiB = chiB_calc(H, Ks)
-    return (
-        ABO3
-        * (-ABO3 * alphaB * chiB + ABO3 * chiB + alphaB * chiB - chiB + 1)
-        / (-ABO3 * alphaB + ABO3 + alphaB))
+    return ((A11 / (1 - A11)) / SRM_ratio - 1) * 1000
+def A11_2_R11(A11):
+    """
+    Convert fractional abundance (A11) to isotope ratio (R11).
 
+    Parameters
+    ----------
+    A11 : array-like
+        The fractional abundance of 11B: 11B / (11B + 10B).
+
+    Returns
+    -------
+    array-like
+        A11 expressed as an isotope ratio (R11).
+    """
+    return A11 / (1 - A11)
+def d11_2_A11(d11, SRM_ratio=4.04367):
+    """
+    Convert delta notation (d11) to fractional abundance (A11).
+
+    Parameters
+    ----------
+    d11 : array-like
+        The isotope ratio expressed in delta notation.
+    SRM_ratio : float, optional
+        The 11B/10B of the SRM, by default NIST951 which is 4.04367
+
+    Returns
+    -------
+    array-like
+       Delta notation (d11) expressed as fractional abundance (A11).
+    """
+    return SRM_ratio * (d11 / 1000 + 1) / (SRM_ratio * (d11 / 1000 + 1) + 1)
+def d11_2_R11(d11, SRM_ratio=4.04367):
+    """
+    Convert delta notation (d11) to isotope ratio (R11).
+
+    Parameters
+    ----------
+    d11 : array-like
+        The isotope ratio expressed in delta notation.
+    SRM_ratio : float, optional
+        The 11B/10B of the SRM, by default NIST951 which is 4.04367
+
+    Returns
+    -------
+    array-like
+       Delta notation (d11) expressed as isotope ratio (R11).
+    """
+    return (d11 / 1000 + 1) * SRM_ratio
+def R11_2_d11(R11, SRM_ratio=4.04367):
+    """
+    Convert isotope ratio (R11) to delta notation (d11).
+
+    Parameters
+    ----------
+    R11 : array-like
+        The isotope ratio (11B/10B).
+    SRM_ratio : float, optional
+        The 11B/10B of the SRM, by default NIST951 which is 4.04367
+
+    Returns
+    -------
+    array-like
+        R11 expressed in delta notation (d11).
+    """
+    return (R11 / SRM_ratio - 1) * 1000
+def R11_2_A11(R11):
+    """
+    Convert isotope ratio (R11) to fractional abundance (A11).
+
+    Parameters
+    ----------
+    R11 : array-like
+        The isotope ratio (11B/10B).
+
+    Returns
+    -------
+    array-like
+        R11 expressed as fractional abundance (A11).
+    """
+    return R11 / (1 + R11)
+
+# Alpha Converters
+def ABO3_to_ABO4(ABO3,alphaB):
+    """
+    Converts isotope fractional abundance of boric acid to isotope fraction abundance of borate ion
+    """
+    return (1 / ((alphaB / ABO3) - alphaB + 1) )
+def ABO3_or_ABO4(ABO3,ABO4,alphaB):
+    """
+    Helper function to determine ABO4 where necessary
+    """
+    if (ABO4 is None and ABO3 is None) or (ABO4 is not None and ABO3 is not None):
+        raise(ValueError("Either ABO4 or ABO3 must be specified"))
+    elif ABO4 is None and ABO3 is not None:
+        ABO4 = ABO3_to_ABO4(ABO3,alphaB)
+    return ABO4
+
+# Base Functions
 # Calculate total boron isotope fractional abundance using borate ion (B(OH)4)
-def ABT_using_ABO4(pH, ABO4, Ks, alphaB):
+def calculate_ABT(Ks, pH, alphaB, ABO4=None, ABO3=None):
     """
     Calculates ABT from pH (total scale) and ABO4.
 
@@ -76,6 +164,8 @@ def ABT_using_ABO4(pH, ABO4, Ks, alphaB):
     array-like
         The fractional abundance of 11B in total B (ABT).
     """
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
+
     H = ch(pH)
     chiB = chiB_calc(H, Ks)
     return (
@@ -91,13 +181,8 @@ def ABT_using_ABO4(pH, ABO4, Ks, alphaB):
         )
         / (ABO4 * alphaB - ABO4 + 1))
 
-
-# Calculate pH using isotope fractional abundance of boric acid (B(OH)3)
-def pH_using_ABO3(ABO3, ABT, Ks, alphaB):
-    pass
-
 # Calculate pH using isotope fractional abundance of borate ion (B(OH)4)
-def pH_using_ABO4(ABO4, ABT, Ks, alphaB):
+def calculate_ApH(Ks, alphaB, ABT, ABO4=None, ABO3=None):
     """
     Calculates pHtot from ABO4 and ABT. 
 
@@ -117,8 +202,9 @@ def pH_using_ABO4(ABO4, ABT, Ks, alphaB):
     array-like
         pH on the Total scale.
     """
-    return -np.log10(Ks.KB / ((alphaB / (1 - ABO4 + alphaB * ABO4) - 1) / (ABT / ABO4 - 1) - 1))
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
 
+    return -np.log10(Ks.KB / ((alphaB / (1 - ABO4 + alphaB * ABO4) - 1) / (ABT / ABO4 - 1) - 1))
 
 # Calculate isotope fractional abundance of boric acid (B(OH)3)
 def calculate_ABO3(H, ABT, Ks, alphaB):
@@ -211,26 +297,25 @@ def calculate_ABO4(H, ABT, Ks, alphaB):
     ) / (2 * alphaB * chiB - 2 * alphaB - 2 * chiB + 2)
 
 # Calculate alpha using isotope fractional abundance of boric acid (B(OH)3)
-def alpha_using_ABO3(ABO3,ABT,H,Ks):
-    pass
+def calculate_alpha_ABO3(Ks,H,ABT,ABO3):
+    return ( (1
+            / ((H/Ks.KB) * (ABT - ABO3) + ABT)) 
+            / (ABO3 -1))
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def alpha_using_ABO4(ABO4,ABT,H,Ks):
-    return ( (H*ABT*(ABO4+1) + (Ks.KB*(ABO4-ABT))) / ((ABO4**2 * (H+Ks.KB)) + (ABO4*(H-(ABT*Ks.KB)))))
-
-
-# Calculate alpha using isotope fractional abundance of borate ion (B(OH)3)
-def KB_using_ABO3(ABO3,ABT,H,alphaB):
-    pass
+def calculate_alpha_ABO4(Ks,H,ABT,ABO4):
+    return ( (1 - ABO4)
+            / (ABO4 / (ABT - ((ABO4-ABT)/(H/Ks.KB))) -ABO4) )
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def KB_using_ABO4(ABO4,ABT,H,alphaB):
+def calculate_AKB(H,alphaB,ABT,ABO4=None,ABO3=None):
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
     return (H
             / ((ABO4 - ABT)
             / ( ABT 
             - 1 / ( (1/alphaB) * (1/ABO4 -1) + 1) )))
 
-
+# Wrapper functions using delta values
 def calculate_pH(Ks,d11BT,d11B4=None,d11B3=None,epsilon=get_epsilonB()):
     """
     Returns pH on the total scale
@@ -250,8 +335,15 @@ def calculate_pH(Ks,d11BT,d11B4=None,d11B3=None,epsilon=get_epsilonB()):
     ABT = d11_2_A11(d11BT)
     alpha = epsilon_2_alpha(epsilon)
 
-    return pH_using_ABO4(ABO4,ABT,Ks,alpha)
+    return calculate_ApH(Ks,alpha,ABT,ABO4)
+def calculate_KB(d11B4,d11BT,pH,epsilon=get_epsilonB()):
+    ABO4 = d11_2_A11(d11B4)
+    ABT = d11_2_A11(d11BT)
+    H = ch(pH)
 
+    alphaB = epsilon_2_alpha(epsilon)
+
+    return calculate_AKB(H,alphaB,ABT,ABO4)
 def calculate_d11BT(d11B4,pH,KB,epsilon=get_epsilonB()):
     """
     Returns isotope ratio of total boron in delta units
@@ -269,9 +361,7 @@ def calculate_d11BT(d11B4,pH,KB,epsilon=get_epsilonB()):
     """
     ABO4 = d11_2_A11(d11B4)
     alpha = epsilon_2_alpha(epsilon)
-
-    return A11_2_d11(ABT_using_ABO4(pH,ABO4,KB,alpha))
-
+    return A11_2_d11(calculate_ABT(KB,pH,alpha,ABO4))
 def calculate_d11B4(d11BT,pH,KB,epsilon=get_epsilonB()):
     """
     Returns isotope ratio of borate ion in delta units
@@ -291,16 +381,6 @@ def calculate_d11B4(d11BT,pH,KB,epsilon=get_epsilonB()):
     alpha = epsilon_2_alpha(epsilon)
 
     return A11_2_d11(calculate_ABO4(ch(pH),ABOT,KB,alpha))
-
-def calculate_KB(d11B4,d11BT,pH,epsilon=get_epsilonB()):
-    ABO4 = d11_2_A11(d11B4)
-    ABT = d11_2_A11(d11BT)
-    H = ch(pH)
-
-    alpha = epsilon_2_alpha(epsilon)
-
-    return KB_using_ABO4(ABO4,ABT,H,alpha)
-
 def calculate_epsilon(d11B4,d11BT,pH,KB):
     """
     Returns isotope ratio of borate ion in delta units
@@ -320,118 +400,6 @@ def calculate_epsilon(d11B4,d11BT,pH,KB):
     ABT = d11_2_A11(d11BT)
     H = ch(pH)
 
-    alpha = alpha_using_ABO4(ABO4,ABT,H,KB)
+    alpha = calculate_alpha_ABO4(KB,H,ABT,ABO4)
 
     return alpha_2_epsilon(alpha)
-    
-
-# Isotope Unit Converters
-def A11_2_d11(A11, SRM_ratio=4.04367):
-    """
-    Convert fractional abundance (A11) to delta notation (d11).
-
-    Parameters
-    ----------
-    A11 : array-like
-        The fractional abundance of 11B: 11B / (11B + 10B).
-    SRM_ratio : float, optional
-        The 11B/10B of the SRM, by default NIST951 which is 4.04367
-
-    Returns
-    -------
-    array-like
-        A11 expressed in delta notation (d11).
-    """
-    return ((A11 / (1 - A11)) / SRM_ratio - 1) * 1000
-
-
-def A11_2_R11(A11):
-    """
-    Convert fractional abundance (A11) to isotope ratio (R11).
-
-    Parameters
-    ----------
-    A11 : array-like
-        The fractional abundance of 11B: 11B / (11B + 10B).
-
-    Returns
-    -------
-    array-like
-        A11 expressed as an isotope ratio (R11).
-    """
-    return A11 / (1 - A11)
-
-
-def d11_2_A11(d11, SRM_ratio=4.04367):
-    """
-    Convert delta notation (d11) to fractional abundance (A11).
-
-    Parameters
-    ----------
-    d11 : array-like
-        The isotope ratio expressed in delta notation.
-    SRM_ratio : float, optional
-        The 11B/10B of the SRM, by default NIST951 which is 4.04367
-
-    Returns
-    -------
-    array-like
-       Delta notation (d11) expressed as fractional abundance (A11).
-    """
-    return SRM_ratio * (d11 / 1000 + 1) / (SRM_ratio * (d11 / 1000 + 1) + 1)
-
-
-def d11_2_R11(d11, SRM_ratio=4.04367):
-    """
-    Convert delta notation (d11) to isotope ratio (R11).
-
-    Parameters
-    ----------
-    d11 : array-like
-        The isotope ratio expressed in delta notation.
-    SRM_ratio : float, optional
-        The 11B/10B of the SRM, by default NIST951 which is 4.04367
-
-    Returns
-    -------
-    array-like
-       Delta notation (d11) expressed as isotope ratio (R11).
-    """
-    return (d11 / 1000 + 1) * SRM_ratio
-
-
-def R11_2_d11(R11, SRM_ratio=4.04367):
-    """
-    Convert isotope ratio (R11) to delta notation (d11).
-
-    Parameters
-    ----------
-    R11 : array-like
-        The isotope ratio (11B/10B).
-    SRM_ratio : float, optional
-        The 11B/10B of the SRM, by default NIST951 which is 4.04367
-
-    Returns
-    -------
-    array-like
-        R11 expressed in delta notation (d11).
-    """
-    return (R11 / SRM_ratio - 1) * 1000
-
-
-def R11_2_A11(R11):
-    """
-    Convert isotope ratio (R11) to fractional abundance (A11).
-
-    Parameters
-    ----------
-    R11 : array-like
-        The isotope ratio (11B/10B).
-
-    Returns
-    -------
-    array-like
-        R11 expressed as fractional abundance (A11).
-    """
-    return R11 / (1 + R11)
-

--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -1,7 +1,7 @@
 # B isotope fns
 
 import numpy as np
-from cbsyst.helpers import ch,cp,Bunch
+from cbsyst.helpers import ch,cp,NnotNone
 from .boron import chiB_calc
 
 def get_alphaB():
@@ -9,6 +9,7 @@ def get_alphaB():
     Klochko alpha for B fractionation
     """
     return 1.0272
+
 def get_epsilonB():
     """
     Klochko epsilon for B fractionation
@@ -30,6 +31,7 @@ def alpha_to_epsilon(alphaB):
         alphaB expressed in delta notation (AKA epsilonB).
     """
     return (alphaB-1)*1000
+
 def epsilon_to_alpha(epsilonB):
     """
     Convert epsilon to alpha
@@ -45,6 +47,7 @@ def epsilon_to_alpha(epsilonB):
         The isotope fractionation factor (11/10 BO3)/(11/10 BO4).
     """
     return (epsilonB/1000)+1
+
 
 # Isotope Unit Converters
 def A11_to_d11(A11, SRM_ratio=4.04367):
@@ -64,6 +67,7 @@ def A11_to_d11(A11, SRM_ratio=4.04367):
         A11 expressed in delta notation (d11).
     """
     return ((A11 / (1 - A11)) / SRM_ratio - 1) * 1000
+
 def A11_to_R11(A11):
     """
     Convert fractional abundance (A11) to isotope ratio (R11).
@@ -79,6 +83,7 @@ def A11_to_R11(A11):
         A11 expressed as an isotope ratio (R11).
     """
     return A11 / (1 - A11)
+
 def d11_to_A11(d11, SRM_ratio=4.04367):
     """
     Convert delta notation (d11) to fractional abundance (A11).
@@ -96,6 +101,7 @@ def d11_to_A11(d11, SRM_ratio=4.04367):
        Delta notation (d11) expressed as fractional abundance (A11).
     """
     return SRM_ratio * (d11 / 1000 + 1) / (SRM_ratio * (d11 / 1000 + 1) + 1)
+
 def d11_to_R11(d11, SRM_ratio=4.04367):
     """
     Convert delta notation (d11) to isotope ratio (R11).
@@ -113,6 +119,7 @@ def d11_to_R11(d11, SRM_ratio=4.04367):
        Delta notation (d11) expressed as isotope ratio (R11).
     """
     return (d11 / 1000 + 1) * SRM_ratio
+
 def R11_to_d11(R11, SRM_ratio=4.04367):
     """
     Convert isotope ratio (R11) to delta notation (d11).
@@ -130,6 +137,7 @@ def R11_to_d11(R11, SRM_ratio=4.04367):
         R11 expressed in delta notation (d11).
     """
     return (R11 / SRM_ratio - 1) * 1000
+
 def R11_to_A11(R11):
     """
     Convert isotope ratio (R11) to fractional abundance (A11).
@@ -147,13 +155,13 @@ def R11_to_A11(R11):
     return R11 / (1 + R11)
 
 # Alpha Converters
-def AB3_to_AB4(AB3,alphaB):
+def ABO3_to_ABO4(ABO3,alphaB):
     """
     Converts isotope fractional abundance of boric acid to isotope fraction abundance of borate ion
 
     Parameters
     ----------
-    AB3 : array-like
+    ABO3 : array-like
         The fractional abundance of boric acid (B(OH)3)
     alphaB : array-like
         The isotope fractionation factor for (11/10 BO3)/(11/10 BO4).
@@ -161,18 +169,19 @@ def AB3_to_AB4(AB3,alphaB):
     Returns
     -------
     array-like
-        AB4 - the fractional abundance of borate ion (B(OH)4)
+        ABO4 - the fractional abundance of borate ion (B(OH)4)
     """
-    return (1 / ((alphaB / AB3) - alphaB + 1) )
-def AB3_or_AB4(AB3,AB4,alphaB):
+    return (1 / ((alphaB / ABO3) - alphaB + 1) )
+
+def ABO3_or_ABO4(ABO3,ABO4,alphaB):
     """
-    Helper function to determine AB4 if AB3 is None
+    Helper function to determine ABO4 if ABO3 is None
 
     Parameters
     ----------
-    AB3 : array-like
+    ABO3 : array-like
         The fractional abundance of boric acid (B(OH)3)
-    AB4 : array-like
+    ABO4 : array-like
         The fractional abundance of borate ion (B(OH)4)
     alphaB : array-like
         The isotope fractionation factor for (11/10 BO3)/(11/10 BO4).
@@ -180,19 +189,20 @@ def AB3_or_AB4(AB3,AB4,alphaB):
     Returns
     -------
     array-like
-        AB4 - the fractional abundance of borate ion (B(OH)4)
+        ABO4 - the fractional abundance of borate ion (B(OH)4)
     """
-    if (AB4 is None and AB3 is None) or (AB4 is not None and AB3 is not None):
-        raise(ValueError("Either AB4 or AB3 must be specified"))
-    elif AB4 is None and AB3 is not None:
-        AB4 = AB3_to_AB4(AB3,alphaB)
-    return AB4
+    if NnotNone(ABO3, ABO4) < 1:
+        raise(ValueError("Either ABO4 or ABO3 must be specified"))
+    elif ABO4 is None:
+        ABO4 = ABO3_to_ABO4(ABO3,alphaB)
+    return ABO4
+
 
 # Base Functions
 # Calculate total boron isotope fractional abundance using borate ion (B(OH)4)
-def calculate_ABT(H, Ks, alphaB, AB4=None, AB3=None):
+def calculate_ABT(H, Ks, alphaB, ABO4=None, ABO3=None):
     """
-    Calculates ABT from pH (total scale) and AB4.
+    Calculates ABT from pH (total scale) and ABO4.
 
     Parameters
     ----------    
@@ -202,9 +212,9 @@ def calculate_ABT(H, Ks, alphaB, AB4=None, AB3=None):
         pH on the Total scale
     alphaB : array-like
         The fractionation factor between B(OH)3 and B(OH)4-
-    AB4 : array-like
+    ABO4 : array-like
         The fractional abundance of 11B in B(OH)4.
-    AB3 : array-like
+    ABO3 : array-like
         The fractional abundance of 11B in B(OH)3.
 
     Returns
@@ -212,26 +222,26 @@ def calculate_ABT(H, Ks, alphaB, AB4=None, AB3=None):
     array-like
         The fractional abundance of 11B in total B (ABT).
     """
-    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
 
     chiB = chiB_calc(H, Ks)
     return (
-        AB4
+        ABO4
         * (
-            -AB4 * alphaB * chiB
-            + AB4 * alphaB
-            + AB4 * chiB
-            - AB4
+            -ABO4 * alphaB * chiB
+            + ABO4 * alphaB
+            + ABO4 * chiB
+            - ABO4
             + alphaB * chiB
             - chiB
             + 1
         )
-        / (AB4 * alphaB - AB4 + 1))
+        / (ABO4 * alphaB - ABO4 + 1))
 
 # Calculate pH using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_H(Ks, alphaB, ABT, AB4=None, AB3=None):
+def calculate_H(Ks, alphaB, ABT, ABO4=None, ABO3=None):
     """
-    Calculates pHtot from AB4 and ABT. 
+    Calculates pHtot from ABO4 and ABT. 
 
     Parameters
     ----------
@@ -241,7 +251,7 @@ def calculate_H(Ks, alphaB, ABT, AB4=None, AB3=None):
         fractionation factor between B(OH)3 and B(OH)4-
     ABT : float or array-like
         fractional abundance of 11B in total B
-    AB4 : float or array-like
+    ABO4 : float or array-like
         fractional abundance of 11B in B(OH)4-
         
     Returns
@@ -249,14 +259,14 @@ def calculate_H(Ks, alphaB, ABT, AB4=None, AB3=None):
     array-like
         pH on the total scale.
     """
-    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
 
-    return (Ks.KB / ((alphaB / (1 - AB4 + alphaB * AB4) - 1) / (ABT / AB4 - 1) - 1))
+    return (Ks.KB / ((alphaB / (1 - ABO4 + alphaB * ABO4) - 1) / (ABT / ABO4 - 1) - 1))
 
 # Calculate isotope fractional abundance of boric acid (B(OH)3)
-def calculate_AB3(H, Ks, ABT, alphaB):
+def calculate_ABO3(H, Ks, ABT, alphaB):
     """
-    Calculate AB3 from H and ABT
+    Calculate ABO3 from H and ABT
 
     Parameters
     ----------
@@ -299,9 +309,9 @@ def calculate_AB3(H, Ks, ABT, alphaB):
     ) / (2 * chiB * (alphaB - 1))
 
 # Calculate isotope fractional abundance of borate ion (B(OH)4)
-def calculate_AB4(H, Ks, ABT, alphaB):
+def calculate_ABO4(H, Ks, ABT, alphaB):
     """
-    Calculate AB4 from H and ABT
+    Calculate ABO4 from H and ABT
 
     Parameters
     ----------
@@ -344,9 +354,9 @@ def calculate_AB4(H, Ks, ABT, alphaB):
     ) / (2 * alphaB * chiB - 2 * alphaB - 2 * chiB + 2)
 
 # Calculate alpha using isotope fractional abundance of boric acid (B(OH)3)
-def calculate_alpha_AB3(H, Ks, ABT, AB3):
+def calculate_alpha_ABO3(H, Ks, ABT, ABO3):
     """
-    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (AB3)
+    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (ABO3)
 
     Parameters
     ----------
@@ -356,7 +366,7 @@ def calculate_alpha_AB3(H, Ks, ABT, AB3):
         The activity of Hydrogen ions in mol kg-1
     ABT : array-like
         The fractional abundance of 11B in total B.
-    AB3 : array-like
+    ABO3 : array-like
         The fractional abundance of 11B in boric acid (B(OH)3).
 
     Returns
@@ -365,13 +375,13 @@ def calculate_alpha_AB3(H, Ks, ABT, AB3):
         The fractionation factor between B(OH)3 and B(OH)4- (alpha)
     """
     return ( (1
-            / ((H/Ks.KB) * (ABT - AB3) + ABT)) 
-            / (AB3 -1))
+            / ((H/Ks.KB) * (ABT - ABO3) + ABT)) 
+            / (ABO3 -1))
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_alpha_AB4(H, Ks, ABT, AB4):
+def calculate_alpha_ABO4(H, Ks, ABT, ABO4):
     """
-    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (AB3)
+    Calculate fractionation factor (alpha) from the fractional abundance of 11B in B(OH)3 (ABO3)
 
     Parameters
     ----------
@@ -381,7 +391,7 @@ def calculate_alpha_AB4(H, Ks, ABT, AB4):
         The activity of Hydrogen ions in mol kg-1
     ABT : array-like
         The fractional abundance of 11B in total B.
-    AB4 : array-like
+    ABO4 : array-like
         The fractional abundance of 11B in borate ion (B(OH)4).
 
     Returns
@@ -389,11 +399,11 @@ def calculate_alpha_AB4(H, Ks, ABT, AB4):
     array-like
         The fractionation factor between B(OH)3 and B(OH)4- (alpha)
     """
-    return ( (1/AB4 - 1)
-            / (1 / (ABT - ((AB4-ABT)/(H/Ks.KB))) -1) )
+    return ( (1/ABO4 - 1)
+            / (1 / (ABT - ((ABO4-ABT)/(H/Ks.KB))) -1) )
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_KB(H, alphaB, ABT, AB4=None, AB3=None):
+def calculate_KB(H, alphaB, ABT, ABO4=None, ABO3=None):
     """
     Calculate stoichiometric equilibrium constant for boron
 
@@ -405,9 +415,9 @@ def calculate_KB(H, alphaB, ABT, AB4=None, AB3=None):
         The fractionation factor between B(OH)3 and B(OH)4-
     ABT : array-like
         The fractional abundance of 11B in total B.
-    AB4 : array-like
+    ABO4 : array-like
         The fractional abundance of 11B in borate ion (B(OH)4).
-    AB3 : array-like
+    ABO3 : array-like
         The fractional abundance of 11B in boric acid (B(OH)3).
 
     Returns
@@ -415,14 +425,14 @@ def calculate_KB(H, alphaB, ABT, AB4=None, AB3=None):
     array-like
         The stoichiometric equilibrium constant for boron (KB)
     """
-    AB4 = AB3_or_AB4(AB3,AB4,alphaB)
+    ABO4 = ABO3_or_ABO4(ABO3,ABO4,alphaB)
     return (H
-            / ((AB4 - ABT)
+            / ((ABO4 - ABT)
             / ( ABT 
-            - 1 / ( (1/alphaB) * (1/AB4 -1) + 1) )))
+            - 1 / ( (1/alphaB) * (1/ABO4 -1) + 1) )))
 
 # Wrapper functions using delta values
-def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
+def calculate_pH(Ks, d11BT, d11B4, epsilon=get_epsilonB()):
     """
     Calculates pH on the total scale
 
@@ -433,20 +443,21 @@ def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
     d11BT : float or array-like
         isotope ratio 11B/10B in total boron - delta units
     d11B4 : float or array-like
-        isotope ratio 11B/10B in BO4 - delta units
+        isotope ratio 11B/10B in BO4 - delta units, in ‰
     epsilon : float or array-like
-        fractionation factor between BO3 and BO4
+        fractionation factor between BO3 and BO4, in ‰
 
     Returns
     ----------
     array-like
         pH on the total scale
     """
-    AB4 = d11_to_A11(d11B4)
+    ABO4 = d11_to_A11(d11B4)
     ABT = d11_to_A11(d11BT)
-    alpha = epsilon_to_alpha(epsilon)
+    alphaB = epsilon_to_alpha(epsilon)
 
-    return cp(calculate_H(Ks,alpha,ABT,AB4))
+    return cp(calculate_H(Ks,alphaB,ABT,ABO4))
+
 def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     """
     Calculate stoichiometric equilibrium constant for boron with delta inputs
@@ -456,24 +467,25 @@ def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     pH : array-like
         pH on the total scale
     d11BT : array-like
-        The isotope ratio of 11B in total B in delta units
+        The isotope ratio of 11B in total B in delta units, in ‰
     d11B4 : array-like
-        The isotope ratio of 11B in borate ion (B(OH)4) in delta units
+        The isotope ratio of 11B in borate ion (B(OH)4) in delta units, in ‰
     epsilonB : array-like
-        The fractionation factor between B(OH)3 and B(OH)4- as delta units
+        The fractionation factor between B(OH)3 and B(OH)4- as delta units, in ‰
 
     Returns
     -------
     array-like
         The stoichiometric equilibrium constant for boron (KB)
     """
-    AB4 = d11_to_A11(d11B4)
+    ABO4 = d11_to_A11(d11B4)
     ABT = d11_to_A11(d11BT)
     H = ch(pH)
 
     alphaB = epsilon_to_alpha(epsilonB)
 
-    return cp(calculate_KB(H,alphaB,ABT,AB4))
+    return cp(calculate_KB(H,alphaB,ABT,ABO4))
+
 def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     """
     Calcluates the isotope ratio of total boron in delta units
@@ -485,19 +497,20 @@ def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     KB : Bunch (dictionary with . access)
         bunch containing the boron speciation constant KB
     d11B4 : float or array-like
-        isotope ratio 11B/10B in BO4 - delta units
+        isotope ratio 11B/10B in BO4 - delta units, in ‰
     epsilonB : float or array-like
-        fractionation factor between BO3 and BO4
+        fractionation factor between BO3 and BO4, units of ‰
 
     Returns
     -------
     array-like
-        The isotope ratio 11B/10B in BT - delta units (d11BT)
+        The isotope ratio 11B/10B in BT - delta units (d11BT), in ‰
     """
-    AB4 = d11_to_A11(d11B4)
-    alpha = epsilon_to_alpha(epsilonB)
+    ABO4 = d11_to_A11(d11B4)
+    alphaB = epsilon_to_alpha(epsilonB)
     H = ch(pH)
-    return A11_to_d11(calculate_ABT(H,KB,alpha,AB4))
+    return A11_to_d11(calculate_ABT(H,KB,alphaB,ABO4))
+
 def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     """
     Calculates the isotope ratio of borate ion in delta units
@@ -509,19 +522,20 @@ def calculate_d11B4(pH, KB, d11BT, epsilonB=get_epsilonB()):
     KB : Bunch (dictionary with . access)
         bunch containing the boron speciation constant KB
     d11BT : float or array-like
-        isotope ratio 11B/10B in total boron - delta units
+        isotope ratio 11B/10B in total boron - delta units, in ‰
     epsilonB : float or array-like
-        fractionation factor between BO3 and BO4
+        fractionation factor between BO3 and BO4, units of ‰
     
     Returns
     -------
     array-like
-        The isotope ratio 11B/10B in BO4 - delta units
+        The isotope ratio 11B/10B in BO4 - delta units, in ‰
     """
     ABOT = d11_to_A11(d11BT)
-    alpha = epsilon_to_alpha(epsilonB)
+    alphaB = epsilon_to_alpha(epsilonB)
 
-    return A11_to_d11(calculate_AB4(ch(pH),KB,ABOT,alpha))
+    return A11_to_d11(calculate_ABO4(ch(pH),KB,ABOT,alphaB))
+
 def calculate_epsilon(pH, KB, d11BT, d11B4):
     """
     Returns isotope ratio of borate ion in delta units
@@ -533,19 +547,19 @@ def calculate_epsilon(pH, KB, d11BT, d11B4):
     KB : Bunch (dictionary with . access)
         bunch containing the boron speciation constant KB
     d11BT : float or array-like
-        isotope ratio 11B/10B in total boron - delta units
+        isotope ratio 11B/10B in total boron - delta units, in ‰
     d11B4 : float or array-like
-        isotope ratio 11B/10B in borate ion (B(OH)4) - delta units
+        isotope ratio 11B/10B in borate ion (B(OH)4) - delta units, in ‰
         
     Returns
     -------
     array-like
-        fractionation factor between BO3 and BO4 in delta units (epsilon)
+        fractionation factor between BO3 and BO4 in delta units (epsilon, in ‰)
     """
-    AB4 = d11_to_A11(d11B4)
+    ABO4 = d11_to_A11(d11B4)
     ABT = d11_to_A11(d11BT)
     H = ch(pH)
 
-    alpha = calculate_alpha_AB4(H,KB,ABT,AB4)
+    alphaB = calculate_alpha_ABO4(H,KB,ABT,ABO4)
 
-    return alpha_to_epsilon(alpha)
+    return alpha_to_epsilon(alphaB)

--- a/cbsyst/boron_isotopes.py
+++ b/cbsyst/boron_isotopes.py
@@ -393,7 +393,7 @@ def calculate_alpha_ABO4(H, Ks, ABT, ABO4):
             / (1 / (ABT - ((ABO4-ABT)/(H/Ks.KB))) -1) )
 
 # Calculate alpha using isotope fractional abundance of borate ion (B(OH)4)
-def calculate_AKB(H, alphaB, ABT, ABO4=None, ABO3=None):
+def calculate_KB(H, alphaB, ABT, ABO4=None, ABO3=None):
     """
     Calculate stoichiometric equilibrium constant for boron
 
@@ -447,7 +447,7 @@ def calculate_pH(Ks, d11BT, d11B4=None, d11B3=None, epsilon=get_epsilonB()):
     alpha = epsilon_2_alpha(epsilon)
 
     return cp(calculate_H(Ks,alpha,ABT,ABO4))
-def calculate_KB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
+def calculate_pKB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
     """
     Calculate stoichiometric equilibrium constant for boron with delta inputs
 
@@ -473,7 +473,7 @@ def calculate_KB(pH, d11BT, d11B4, epsilonB=get_epsilonB()):
 
     alphaB = epsilon_2_alpha(epsilonB)
 
-    return calculate_AKB(H,alphaB,ABT,ABO4)
+    return cp(calculate_KB(H,alphaB,ABT,ABO4))
 def calculate_d11BT(pH, KB, d11B4, epsilonB=get_epsilonB()):
     """
     Calcluates the isotope ratio of total boron in delta units

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_to_A11, A11_to_d11, calculate_pH, get_alphaB, calculate_AB3, calculate_AB4
+from cbsyst.boron_isotopes import d11_to_A11, A11_to_d11, calculate_pH, get_alphaB, calculate_ABO3, calculate_ABO4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -642,9 +642,9 @@ def ABsys(
         raise ValueError("pH must be determined to calculate isotopes.")
 
     if ps.ABO3 is None:
-        ps.ABO3 = calculate_AB3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     if ps.ABO4 is None:
-        ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     if ps.dBT is None:
         ps.dBT = A11_to_d11(ps.ABT)
@@ -988,9 +988,9 @@ def CBsys(
     #     raise ValueError("pH must be determined to calculate isotopes.")
 
     # if ps.ABO3 is None:
-    #     ps.ABO3 = calculate_AB3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     # if ps.ABO4 is None:
-    #     ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     # if ps.dBT is None:
     #     ps.dBT = A11_to_d11(ps.ABT)

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, pH_ABO3, alphaB_calc, cABO3, cABO4
+from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, pH_using_ABO3, get_alphaB, calculate_ABO3, calculate_ABO4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -628,23 +628,23 @@ def ABsys(
 
     # calculate alpha
     if alphaB is None:
-        ps.alphaB = alphaB_calc(TempC=ps.T_in)
+        ps.alphaB = get_alphaB(TempC=ps.T_in)
     else:
         ps.alphaB = alphaB
 
     if ps.pHtot is not None and ps.ABT is not None:
         ps.H = ch(ps.pHtot)
     elif ps.pHtot is not None and ps.ABO3 is not None:
-        ps.ABT = pH_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
+        ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
     elif ps.pHtot is not None and ps.ABO4 is not None:
-        ps.ABT = pH_ABO3(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
+        ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
     else:
         raise ValueError("pH must be determined to calculate isotopes.")
 
     if ps.ABO3 is None:
-        ps.ABO3 = cABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     if ps.ABO4 is None:
-        ps.ABO4 = cABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     if ps.dBT is None:
         ps.dBT = A11_2_d11(ps.ABT)
@@ -974,23 +974,23 @@ def CBsys(
 
     # calculate alpha
     if alphaB is None:
-        ps.alphaB = alphaB_calc(TempC=ps.T_in)
+        ps.alphaB = get_alphaB(TempC=ps.T_in)
     else:
         ps.alphaB = alphaB
 
     # if ps.pHtot is not None and ps.ABT is not None:
     #     ps.H = ch(ps.pHtot)
     # elif ps.pHtot is not None and ps.ABO3 is not None:
-    #     ps.ABT = pH_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
+    #     ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
     # elif ps.pHtot is not None and ps.ABO4 is not None:
-    #     ps.ABT = pH_ABO3(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
+    #     ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
     # else:
     #     raise ValueError("pH must be determined to calculate isotopes.")
 
     # if ps.ABO3 is None:
-    #     ps.ABO3 = cABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     # if ps.ABO4 is None:
-    #     ps.ABO4 = cABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     # if ps.dBT is None:
     #     ps.dBT = A11_2_d11(ps.ABT)

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, calculate_pH, get_alphaB, calculate_AB3, calculate_AB4
+from cbsyst.boron_isotopes import d11_to_A11, A11_to_d11, calculate_pH, get_alphaB, calculate_AB3, calculate_AB4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -620,11 +620,11 @@ def ABsys(
 
     # if deltas provided, calculate corresponding As
     if ps.dBT is not None:
-        ps.ABT = d11_2_A11(ps.dBT)
+        ps.ABT = d11_to_A11(ps.dBT)
     if ps.dBO3 is not None:
-        ps.ABO3 = d11_2_A11(ps.dBO3)
+        ps.ABO3 = d11_to_A11(ps.dBO3)
     if ps.dBO4 is not None:
-        ps.ABO4 = d11_2_A11(ps.dBO4)
+        ps.ABO4 = d11_to_A11(ps.dBO4)
 
     # calculate alpha
     if alphaB is None:
@@ -647,11 +647,11 @@ def ABsys(
         ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     if ps.dBT is None:
-        ps.dBT = A11_2_d11(ps.ABT)
+        ps.dBT = A11_to_d11(ps.ABT)
     if ps.dBO3 is None:
-        ps.dBO3 = A11_2_d11(ps.ABO3)
+        ps.dBO3 = A11_to_d11(ps.ABO3)
     if ps.dBO4 is None:
-        ps.dBO4 = A11_2_d11(ps.ABO4)
+        ps.dBO4 = A11_to_d11(ps.ABO4)
 
     for k in [
         "ABO3",
@@ -966,11 +966,11 @@ def CBsys(
     #     ps.dBT = 0
     # # if deltas provided, calculate corresponding As
     # if ps.dBT is not None:
-    #     ps.ABT = d11_2_A11(ps.dBT)
+    #     ps.ABT = d11_to_A11(ps.dBT)
     # if ps.dBO3 is not None:
-    #     ps.ABO3 = d11_2_A11(ps.dBO3)
+    #     ps.ABO3 = d11_to_A11(ps.dBO3)
     # if ps.dBO4 is not None:
-    #     ps.ABO4 = d11_2_A11(ps.dBO4)
+    #     ps.ABO4 = d11_to_A11(ps.dBO4)
 
     # calculate alpha
     if alphaB is None:
@@ -993,11 +993,11 @@ def CBsys(
     #     ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     # if ps.dBT is None:
-    #     ps.dBT = A11_2_d11(ps.ABT)
+    #     ps.dBT = A11_to_d11(ps.ABT)
     # if ps.dBO3 is None:
-    #     ps.dBO3 = A11_2_d11(ps.ABO3)
+    #     ps.dBO3 = A11_to_d11(ps.ABO3)
     # if ps.dBO4 is None:
-    #     ps.dBO4 = A11_2_d11(ps.ABO4)
+    #     ps.dBO4 = A11_to_d11(ps.ABO4)
 
     # clean up output
     outputs = [

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, calculate_pH, get_alphaB, calculate_ABO3, calculate_ABO4
+from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, calculate_pH, get_alphaB, calculate_AB3, calculate_AB4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -642,9 +642,9 @@ def ABsys(
         raise ValueError("pH must be determined to calculate isotopes.")
 
     if ps.ABO3 is None:
-        ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO3 = calculate_AB3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     if ps.ABO4 is None:
-        ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+        ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     if ps.dBT is None:
         ps.dBT = A11_2_d11(ps.ABT)
@@ -988,9 +988,9 @@ def CBsys(
     #     raise ValueError("pH must be determined to calculate isotopes.")
 
     # if ps.ABO3 is None:
-    #     ps.ABO3 = calculate_ABO3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO3 = calculate_AB3(ps.H, ps.ABT, ps.Ks, ps.alphaB)
     # if ps.ABO4 is None:
-    #     ps.ABO4 = calculate_ABO4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
+    #     ps.ABO4 = calculate_AB4(ps.H, ps.ABT, ps.Ks, ps.alphaB)
 
     # if ps.dBT is None:
     #     ps.dBT = A11_2_d11(ps.ABT)

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, pH_using_ABO3, get_alphaB, calculate_ABO3, calculate_ABO4
+from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, pH_using_ABO3, pH_using_ABO4, get_alphaB, calculate_ABO3, calculate_ABO4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -637,7 +637,7 @@ def ABsys(
     elif ps.pHtot is not None and ps.ABO3 is not None:
         ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
     elif ps.pHtot is not None and ps.ABO4 is not None:
-        ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
+        ps.ABT = pH_using_ABO4(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
     else:
         raise ValueError("pH must be determined to calculate isotopes.")
 

--- a/cbsyst/cbsyst.py
+++ b/cbsyst/cbsyst.py
@@ -8,7 +8,7 @@ from cbsyst.helpers import Bunch, maxL
 # from cbsyst.MyAMI_V2 import MyAMI_K_calc, MyAMI_K_calc_multi, MyAMI_K_calc_direct
 from cbsyst.carbon import calc_C_species, calc_revelle_factor, pCO2_to_fCO2, fCO2_to_CO2
 from cbsyst.boron import calc_B_species
-from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, pH_using_ABO3, pH_using_ABO4, get_alphaB, calculate_ABO3, calculate_ABO4
+from cbsyst.boron_isotopes import d11_2_A11, A11_2_d11, calculate_pH, get_alphaB, calculate_ABO3, calculate_ABO4
 from cbsyst.helpers import ch, cp, NnotNone, calc_TF, calc_TS, calc_TB, calc_pH_scales
 
 
@@ -635,9 +635,9 @@ def ABsys(
     if ps.pHtot is not None and ps.ABT is not None:
         ps.H = ch(ps.pHtot)
     elif ps.pHtot is not None and ps.ABO3 is not None:
-        ps.ABT = pH_using_ABO3(ps.pHtot, ps.ABO3, ps.Ks, ps.alphaB)
+        ps.ABT = calculate_pH(ps.pHtot, ps.Ks, ps.alphaB,ABO3=ps.ABO3)
     elif ps.pHtot is not None and ps.ABO4 is not None:
-        ps.ABT = pH_using_ABO4(ps.pHtot, ps.ABO4, ps.Ks, ps.alphaB)
+        ps.ABT = calculate_pH(ps.pHtot, ps.Ks, ps.alphaB, ps.ABO4)
     else:
         raise ValueError("pH must be determined to calculate isotopes.")
 


### PR DESCRIPTION
Updated boron isotope functions to include:

- Functions for calculations in isotope fractional abundance, supplementing those that were originally there
- Functions for calculations in delta space (i.e. using d11B in place of fractional abundance)
- Full docs for each function
- Nomenclature from ABO3, ABO4 and ABT to AB3, AB4 and ABT (as well as d11B4, d11BT)
- Consistent x_to_y (replacing instance of x_2_y)